### PR TITLE
Running cue and countdown resolution

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -66,7 +66,7 @@ To use the following, replace INSTANCENAME with the name of your module instance
 * **$(INSTANCENAME:r_hh)**: Hours left for Running Cue
 * **$(INSTANCENAME:r_mm)**: Minutes left for Running Cue
 * **$(INSTANCENAME:r_ss)**: Seconds left for Running Cue
-* **$(INSTANCENAME:r_left)**: Shortest display time left for Running Cue
+* **$(INSTANCENAME:r_left)**: Shortest display time left for Running Cue. Shows .1 increments if tenths option set.
 
 
 ## Feedback available (TCP mode only)

--- a/HELP.md
+++ b/HELP.md
@@ -12,6 +12,13 @@ This may cause a noticible increase in network traffic.
 
 This module was tested against QLab4. Nothing specific to QLab4 is used, so QLab3 should work, too.
 
+## Configuration
+* **Target IP** Enter the address of the QLab computer. You can enter 127.0.0.1 if Companion is running on the same computer.
+* **Use TCP?** Check to enable TCP mode. This is required for variables and feedback.
+* **Use Tenths** If checked, the variable *r_left* will display 0.1 seconds when less than 5 seconds. If unchecked, the time left will be adjusted by 1 second for a more accurate count-down.
+* **OSC Passcode** Enter a passcode if needed for the QLab workspace.
+* **Workspace** Enter the workspace title or ID to control a specific QLab workspace.
+
 ## Actions
 
 The following actions are available:
@@ -61,8 +68,6 @@ To use the following, replace INSTANCENAME with the name of your module instance
 * **$(INSTANCENAME:r_ss)**: Seconds left for Running Cue
 * **$(INSTANCENAME:r_left)**: Shortest display time left for Running Cue
 
-Explaination of 'Running Cue'. [^1]
-
 
 ## Feedback available (TCP mode only)
 
@@ -76,8 +81,9 @@ This module connects to QLab on port 53000.
 From Qlab preferences OSC controls tab make sure you have the "Use OSC controls" checkbox ticked.
 ![Qlab](images/qlab.jpg?raw=true "Qlab")
 
+### Running cue examples
+ QLab can run many cues at the same time while Stream Deck has a limited number of buttons visible at once. So which *one* cue is the most useful to show on a button? This module looks for the most recently run (GO) cue and favors *run all at once* Group cues over other types of cues.
 
-[^1]: QLab can run many cues at the same time so which *one* cue is the most useful to show on a button?
-This module looks for the most recent running (GO) cue and favors **Group** cues over other types of cues.
-An example: In a video show, 5 slides overlap in order (Slide 1, Slide 2, etc) from separate cues,
-after 5 'GO's all 5 cues are 'Running' resulting in a 5 picture overlay. This module uses the last 'GO' in the sequence for the 'Running' cue. More complex: add 2 more screens and wrap each slide in a **Group** cue (with left, right, and center screens for each slide). Now there are 20 cues running, 5 sllides for each screen plus 5 groups cues. The last 'GO' **Group** cue will be source for the variables and feedback.
+- Using a video show... 5 slide cues overlap to build a final image. After 5 'GO's all 5 cues are 'Running' resulting in a 5 picture overlay. The last 'GO' cue in the sequence will be the 'Running' cue.
+- Now add 2 more screens with more images. Each transition (1 image for each screen) is now placed in a *run all* Group cue for list management. After the 5 group cues are run, QLab will show 20 cues active, 5 slides for each screen plus the 5 group cues. The last 'GO' **Group** cue will be the 'Running' cue.
+- If the last 'GO' Group cue is *enter then run each*, the most recent 'GO' cue in the group will be the 'Running' cue.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "qlab-advance",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "qlab-advance",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/qlabfb.js
+++ b/qlabfb.js
@@ -131,7 +131,7 @@ instance.prototype.updateRunning = function () {
 	var mm = ('00' + m).slice(-2);
 	var s = Math.floor(tLeft % 60);
 	var ss = ('00' + s).slice(-2);
-	var ms = tLeft - Math.trunc(tLeft);
+	// var ms = tLeft - Math.trunc(tLeft);
 	var ft = '';
 
 	if (hh>0) {
@@ -432,9 +432,10 @@ instance.prototype.prime_vars = function (ws) {
 		} else {
 			self.sendOSC(ws + "/connect", []);
 		}
+		self.sendOSC(ws + "/version");
+
 		// request variable/feedback info
 		// get list of running cues
-		self.sendOSC(ws + "/version");
 		self.sendOSC(ws + "/cue/playhead/uniqueID", []);
 		self.sendOSC(ws + "/updates", [
 			{
@@ -497,7 +498,6 @@ instance.prototype.init_osc = function () {
 			debug("Error", err);
 			self.log('error', "Error: " + err.message);
 			self.connecting = false;
-			self.ready = false;
 			self.status(self.STATUS_ERROR, "Can't connect to QLab");
 			if (err.code == "ECONNREFUSED") {
 				self.qSocket.removeAllListeners();
@@ -523,15 +523,15 @@ instance.prototype.init_osc = function () {
 				debug("Connection closed");
 				self.ready = false;
 				self.status(self.STATUS_WARNING, "CLOSED");
-				if (self.timer !== undefined) {
-					clearTimeout(self.timer);
-				}
-				if (self.pulse !== undefined) {
-					clearInterval(self.pulse);
-					self.pulse = undefined;
-				}
-				self.timer = setTimeout(function () { self.connect(); }, 5000);
 			}
+			if (self.timer !== undefined) {
+				clearTimeout(self.timer);
+			}
+			if (self.pulse !== undefined) {
+				clearInterval(self.pulse);
+				self.pulse = undefined;
+			}
+			self.timer = setTimeout(function () { self.connect(); }, 5000);
 		});
 
 		self.qSocket.on("ready", function () {
@@ -766,7 +766,7 @@ instance.prototype.readReply = function (message) {
 	if (ma.match(/updates$/)) {
 		self.needWorkspace = false;
 		self.status(self.STATUS_OK, "Connected to QLab");
-		self.pulse = setInterval(function() { self.rePulse(ws); }, 50);
+		self.pulse = setInterval(function() { self.rePulse(ws); }, 100);
 	} else if (ma.match(/version$/)) {
 		if (j.data != undefined) {
 			self.setVariable('q_ver', j.data);
@@ -1988,6 +1988,7 @@ instance.prototype.action = function (action) {
 	}
 	if (self.useTCP && cmd == '/auditionWindow') {
 		self.sendOSC(ws + cmd, []);
+		self.sendOSC(ws + "/cue/playhead/valuesForKeys",qCueRequest);
 	}
 
 };


### PR DESCRIPTION
Based on facebook comments:
- Refined the logic for choosing which cue to use as the _Running_ cue.
- Added a time-left resolution option: 
- 1. Display .1 seconds for time less than 5 seconds
- 2. Add 1 second to time left so zero means zero, not zero plus.
- Update HELP.md
- bump version in package.json