### PR TITLE
New GoTo action, HELP update, version bump

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -30,7 +30,8 @@ The following actions are available:
 * **Reset:** Reset the workspace. Resetting stops all cues, returns the playhead to the top of the current cue list, and restores any temporary changes made to cues (such as retargeting via a Target cue or adjustments using a "live" OSC method.)
 * **Next:** Move the selection down one cue.
 * **Previous:** Move the selection up one cue.
-* **Start (cue):** Start the specified cue. If the specified cue is playing, this command has no effect.
+* **GoTo (cue):** Move the playhead to (cue). Doesn't start the cue.
+* **Start (cue):** Start (cue). Doesn't move the playhead. If the specified cue is playing, this command has no effect.
 * **Preview:** Preview the selected cue without moving the Playhead.
 * **Show Mode** Enable for Show Mode, Disable for Edit Mode.
 * **Audition Window** Show or Hide the Audition Window.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "qlab-advance",
-	"version": "1.0.9",
+	"version": "1.0.10",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/qlabfb.js
+++ b/qlabfb.js
@@ -1675,6 +1675,15 @@ instance.prototype.actions = function (system) {
 				default: "1"
 			}]
 		},
+		'goto': {
+			label: 'Go To (cue)',
+			options: [{
+				type: 'textinput',
+				label: 'Cue',
+				id: 'cue',
+				default: "1"
+			}]
+		},
 		'prewait_dec': {
 			label: 'Decrease Prewait',
 			options: [{
@@ -1847,6 +1856,11 @@ instance.prototype.action = function (action) {
 		case 'start':
 			arg = null;
 			cmd = '/cue/' + opt.cue + '/start';
+			break;
+
+		case 'goto':
+			arg = null;
+			cmd = '/playhead/' + opt.cue;
 			break;
 
 		case 'go':


### PR DESCRIPTION
Added a GoTo (cue) action: Moves the playhead to (cue), doesn't run it.
Inverse of Start (cue): Starts (cue) without moving the playhead.