### PR TITLE
Add internal logic specific to QLab3 to enable feedback/variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"author": "John A Knight Jr <jjr@ayesti.com>",
-	"contributors": [ "Per Røine <per.roine@gmail.com>" ],
+	"contributors": [
+		"Per Røine <per.roine@gmail.com>"
+	],
 	"license": "MIT",
 	"dependencies": {
 		"osc": "^2.3.0"


### PR DESCRIPTION
QLab4 has a cue data query that returns the necessary info for the Feedback and Variables in one response. QLab3 needs a follow-up request to retrieve the cue status.