### PR TITLE
Found a stale timer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "qlab-advance",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",

--- a/qlabfb.js
+++ b/qlabfb.js
@@ -524,6 +524,10 @@ instance.prototype.prime_vars = function (ws) {
 		self.sendOSC(ws + "/cueLists", []);
 		self.sendOSC(ws + "/auditionWindow",[]);
 		self.sendOSC(ws + "/showMode",[]);
+		if (self.timer !== undefined) {
+			clearTimeout(self.timer);
+			self.timer = undefined;
+		}
 		self.timer = setTimeout(function () { self.prime_vars(ws); }, 5000);
 	}
 };


### PR DESCRIPTION
Found this one by accident. I created a button to enable/disable the instance since I'm working on some other modules and don't always need QLab running. The timer still fired once after disabling the instance. It's an edge case and not a memory/resource hog. 