### PR TITLE
Reduce log clutter

### DIFF
--- a/qlabfb.js
+++ b/qlabfb.js
@@ -13,6 +13,7 @@ function instance(system, id, config) {
 	self.needPasscode = false;
 	self.useTCP = config.useTCP;
 	self.qLab3 = false;
+	self.hasError = false;
 
 	self.ws = '';
 
@@ -580,9 +581,12 @@ instance.prototype.init_osc = function () {
 
 		self.qSocket.on("error", function (err) {
 			debug("Error", err);
-			self.log('error', "Error: " + err.message);
 			self.connecting = false;
-			self.status(self.STATUS_ERROR, "Can't connect to QLab");
+			if (!self.hasError) {
+				self.log('error', "Error: " + err.message);
+				self.status(self.STATUS_ERROR, "Can't connect to QLab");
+				self.hasError = true;
+			}
 			if (err.code == "ECONNREFUSED") {
 				self.qSocket.removeAllListeners();
 				if (self.timer !== undefined) {
@@ -622,6 +626,7 @@ instance.prototype.init_osc = function () {
 		self.qSocket.on("ready", function () {
 			self.ready = true;
 			self.connecting = false;
+			self.hasError = false;
 			self.log('info',"Connected to QLab:" + self.config.host);
 			self.status(self.STATUS_WARNING, "No Workspaces");
 			self.needWorkspace = true;


### PR DESCRIPTION
The first lost/can't connect will show in the log, the rest are suppressed. The module will continue connecting to QLab without logging every attempt.
The connect function is also handles the re-connect on network errors (cable removed, wireless dropout). The init_osc() call from the there starts the process to initialize variables and feedback for the rest of the module.
